### PR TITLE
feat: JWT auth test updates + registration endpoint and tests

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.contrib.auth.password_validation import validate_password
 from .models import User, Community, Post, Comment, PostVote, CommentVote, Subscription
 
 class UserSerializer(serializers.ModelSerializer):
@@ -27,6 +28,31 @@ class UserSerializer(serializers.ModelSerializer):
             instance.set_password(password)
         instance.save()
         return instance
+    
+class RegistrationSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True, required=True)
+    password2 = serializers.CharField(write_only=True, required=True, label="Confirm password")
+
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'password', 'password2']
+
+    def validate(self, attrs):
+        if attrs['password'] != attrs['password2']:
+            raise serializers.ValidationError({"password2": "Passwords do not match."})
+        return attrs
+
+    def validate_password(self, value):
+        validate_password(value)
+        return value
+
+    def create(self, validated_data):
+        validated_data.pop('password2')
+        password = validated_data.pop('password')
+        user = User(**validated_data)
+        user.set_password(password)
+        user.save()
+        return user
 
 class CommunitySerializer(serializers.ModelSerializer):
     creator = serializers.PrimaryKeyRelatedField(read_only=True)

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,6 +8,7 @@ from .views import (
     PostDetail,
     CommentList,
     CommentDetail,
+    RegisterView,
 )
 
 app_name = 'api'
@@ -21,4 +22,5 @@ urlpatterns = [
     path('posts/<int:pk>/', PostDetail.as_view(), name='post-detail'),
     path('comments/', CommentList.as_view(), name='comment-list'),
     path('comments/<int:pk>/', CommentDetail.as_view(), name='comment-detail'),
+    path("auth/register/", RegisterView.as_view(), name="auth_register"),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,11 +1,14 @@
-from rest_framework import generics
-from rest_framework.permissions import IsAuthenticated
+from rest_framework import generics, status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework_simplejwt.tokens import RefreshToken
 from .models import User, Community, Post, Comment
 from .serializers import (
     UserSerializer,
     CommunitySerializer,
     PostSerializer,
     CommentSerializer,
+    RegistrationSerializer,
 )
 
 class UserList(generics.ListCreateAPIView):
@@ -17,6 +20,23 @@ class UserDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     permission_classes = [IsAuthenticated]
+
+class RegisterView(generics.CreateAPIView):
+    permission_classes = [AllowAny]
+    serializer_class = RegistrationSerializer
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        refresh = RefreshToken.for_user(user)
+        data = {
+            "user": UserSerializer(user).data,
+            "refresh": str(refresh),
+            "access": str(refresh.access_token),
+        }
+        headers = self.get_success_headers(serializer.data)
+        return Response(data, status=status.HTTP_201_CREATED, headers=headers)
 
 class CommunityList(generics.ListCreateAPIView):
     queryset = Community.objects.all()


### PR DESCRIPTION
Summary
- Add RegistrationSerializer with password confirmation and Django password validation.
- Add RegisterView (AllowAny) that creates a user and returns access/refresh tokens.
- Wire route at /api/auth/register/.
- Require auth for collection/detail views (User, Community, Post, Comment) and rely on request.user assignment in serializers.
- Update tests to work with JWT-protected APIs and server-side ownership assignment.

Details
- serializers.py
  - Added RegistrationSerializer (password, password2, validate_password) and hashing in create().
- views.py
  - Added RegisterView; on success returns { user, access, refresh }.
- api/urls.py
  - Added path("auth/register/", RegisterView.as_view(), name="auth_register").
- tests/conftest.py
  - Added fixtures: access_token (obtains JWT via /api/token/) and auth_client (provides Authorization header).
- tests/test_views.py
  - Updated User/Community/Post/Comment tests to use auth_client and to not send user/creator in payloads (now set from request.user).
  - Added TestRegistration covering success (returns tokens and creates user) and mismatched passwords (400 with error).

Why
- Move to stateless JWT auth for protected resources.
- Prevent clients from spoofing ownership; serializers set user/creator from authenticated identity.
- Provide a first-class registration flow that onboards users and authenticates immediately.

How to verify
- Run `pytest` (all tests should pass).
- Manual:
  1) POST /api/auth/register/ with username, email, password, password2.
  2) Use returned access token to call protected endpoints (e.g., GET /api/users/).
  3) Obtain refresh at /api/token/refresh/ when access expires.

Notes
- Access tokens are short-lived; refresh tokens are longer-lived. Blacklist is optional and not required for this PR.
- If you prefer not to auto-login on registration, we can omit token issuance and return only the user object.