### PR TITLE
Update .gitignore for Python/Django tooling and CI SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,48 @@ db.sqlite3-journal
 
 # Environment variables
 .env
+
+# ...existing code...
+
+# Pipenv virtualenvs
+.venv/
+
+# SQLite used in CI/local override
+ci.sqlite3
+ci.sqlite3-journal
+
+# Pytest
+.pytest_cache/
+
+# Coverage
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Type checkers / linters
+.mypy_cache/
+.pytype/
+.ruff_cache/
+
+# Packaging/build
+build/
+dist/
+*.egg-info/
+.eggs/
+pip-wheel-metadata/
+
+# IDE/editor
+.idea/
+.DS_Store
+Thumbs.db
+
+# Env tools
+.env.local
+.env.*.local
+.envrc
+.direnv/
+
+# Django collectstatic / uploads (if configured)
+staticfiles/
+media/

--- a/.vscode/copilot-instructions.md
+++ b/.vscode/copilot-instructions.md
@@ -1,0 +1,92 @@
+# GitHub Pull Request Workflow Rules
+
+## Project Context
+
+This is a **Python/Django REST Framework** application.
+
+### Technology Stack
+- **Backend Framework**: Django with Django REST Framework (DRF)
+- **Language**: Python
+- **API Style**: RESTful APIs
+
+### Code Standards
+- Follow PEP 8 style guidelines for Python code
+- Use Django and DRF best practices (CBVs, serializers, viewsets)
+- Maintain consistent naming conventions for models, views, serializers, and URLs
+- Write docstrings for complex functions and classes
+- Keep business logic in models or service layers, not in views
+
+### Testing Expectations
+- Write unit tests for models, serializers, and business logic
+- Include API endpoint tests for views
+- Ensure migrations are included for model changes
+- Test authentication and permission requirements
+
+### Common Patterns
+- Use DRF serializers for data validation and transformation
+- Implement proper permission classes for API endpoints
+- Use Django's ORM efficiently (avoid N+1 queries)
+- Follow REST principles for endpoint design
+- Use appropriate HTTP status codes in responses
+
+### PR Requirements
+- Include database migrations if models are modified
+- Update API documentation if endpoints change
+- Consider backwards compatibility for API changes
+- Note any new dependencies in requirements.txt
+
+## Push and PR Creation Workflow
+
+When I ask you to push commits and create a PR, follow these steps:
+
+1. **Push the feature branch**
+   - Push the current branch to GitHub using the GitHub MCP server
+   - Confirm the push was successful
+
+2. **Generate and review diff**
+   - Run `git diff main` (or `git diff main...HEAD` for three-dot diff) to show changes between the feature branch and main
+   - If the diff output is truncated or I need more detail, use `cat` or other tools to examine the full diff
+   - Wait for my review of the diff before proceeding
+
+3. **Create Pull Request**
+   - Open a new pull request from the feature branch to main
+   - **PR Title**: Use a clear, concise title that summarizes the changes
+   - **PR Description**: Include the following sections:
+     
+     ### Changes
+     - Provide a detailed description of what was changed and why
+     - List key modifications, new features, or bug fixes
+     - Reference any relevant issue numbers
+     
+     ### Technical Details
+     - Highlight important implementation details
+     - Note any architectural decisions or trade-offs
+     - Mention dependencies added or updated
+     
+     ### Testing Steps
+     - Provide step-by-step instructions for testing the changes
+     - Include any setup requirements or test data needed
+     - List expected outcomes for each test scenario
+     - Mention any edge cases to verify
+     
+     ### Additional Notes
+     - Note any breaking changes or migration steps
+     - Mention areas that need special review attention
+     - Include screenshots or examples if helpful
+
+4. **Confirmation**
+   - Provide the PR URL and number
+   - Summarize what was included in the PR
+
+## Usage Examples
+
+**Example request**: "Push this and create a PR"
+**Example request**: "Push my changes and open a pull request"
+**Example request**: "Ready to push and PR this feature"
+
+## Notes
+- Always wait for my confirmation after showing the diff before creating the PR
+- If I say "cat the output", examine the full diff content before proceeding
+- For complex changes, be extra thorough in the testing steps section
+- Tailor the level of detail to the size and complexity of the changes
+- Ask any clarifying questions that you have


### PR DESCRIPTION
This PR improves the repo’s .gitignore to avoid committing local build/test artifacts and editor caches. It also adds a copilot instructions file.

Highlights:
- Add Pipenv in-project venv: `.venv/`
- Add CI/local SQLite db files: `ci.sqlite3`, `ci.sqlite3-journal`
- Ignore pytest and coverage outputs: `.pytest_cache/`, `.coverage*`, `htmlcov/`, `coverage.xml`
- Ignore type-checker/linter caches: `.mypy_cache/`, `.pytype/`, `.ruff_cache/`
- Ignore packaging/build outputs: `build/`, `dist/`, `*.egg-info/`, `.eggs/`, `pip-wheel-metadata/`
- Ignore common IDE/OS files: `.idea/`, `.DS_Store`, `Thumbs.db`
- Ignore env tooling files: `.env.local`, `.env.*.local`, `.envrc`, `.direnv/`
- Ignore Django collectstatic/uploads (if configured later): `staticfiles/`, `media/`

Notes:
- `db.sqlite3` remains ignored (already in .gitignore); it is currently tracked in the repo, so this change won’t remove it but will prevent re-adding if removed.
- Keeping `.vscode/` tracked for now since the repo includes useful editor config; we can revisit if you prefer to ignore it.

No code changes; only .gitignore housekeeping.
