### PR TITLE
Chore: Dockerfile, docker-compose, entrypoint, .env-driven ports, README updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.py[cod]
+*.log
+.pytest_cache/
+.mypy_cache/
+.venv/
+.env
+.env.*
+.git/
+.github/
+.vscode/
+db.sqlite3
+*.sqlite3
+Dockerfile*
+docker-compose*.yml
+node_modules/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Database (MYSQL_HOST is set via compose to the db service name)
+MYSQL_DB=hennepin
+MYSQL_USER=hennepin_user
+MYSQL_PASSWORD=password
+MYSQL_HOST=
+MYSQL_PORT=3306
+
+
+# Host port mappings used by docker-compose (set before running `docker compose up`)
+# WEB_PORT: host port for Django app; DB_PORT: host port exposing MySQL for GUI tools.
+# Adjust to avoid conflicts with services already running on your machine.
+WEB_PORT=8000
+DB_PORT=3307
+
+# Django
+DJANGO_DEBUG=1
+DJANGO_ALLOWED_HOSTS=*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# System deps for mysqlclient and utilities
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    default-libmysqlclient-dev \
+    pkg-config \
+    netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python deps via Pipenv using the lockfile for reproducibility
+COPY Pipfile Pipfile.lock /app/
+RUN pip install --no-cache-dir pipenv && \
+    PIPENV_NOSPIN=1 PIPENV_VENV_IN_PROJECT=1 pipenv install --system --deploy
+
+# Copy project
+COPY . /app
+
+# Ensure entrypoint is executable
+RUN chmod +x /app/docker/entrypoint.sh
+
+EXPOSE 8000
+
+CMD ["/app/docker/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+# Hennepin – Dockerized Dev Setup
+
+This repo contains a Django + DRF API. The project is containerized with Docker so you can spin it up quickly with a MySQL database.
+
+## Prereqs
+
+- Docker and Docker Compose v2
+
+## Quick start
+
+1. Configure ports in your .env (required before build/up):
+
+   The docker-compose file reads host ports from the project `.env` file (Compose uses this for variable substitution):
+
+   - `WEB_PORT` — host port for the Django app (default 8000)
+   - `DB_PORT` — host port to expose MySQL for tools like DBeaver (default 3307)
+
+   Example `.env` additions:
+
+   ```env
+   WEB_PORT=8000
+   DB_PORT=3308
+   ```
+
+   Pick values that don’t conflict with anything already listening on your machine.
+
+2. Build and start the stack:
+
+   ```sh
+   docker compose up --build
+   ```
+
+   - Web API: http://localhost:${WEB_PORT}/
+   - MySQL for GUI clients (e.g., DBeaver): localhost:${DB_PORT}
+   - The container will wait for MySQL, run migrations, then start the Django dev server.
+
+3. Stop the stack:
+
+   ```sh
+   docker compose down
+   ```
+
+   Add `-v` to remove the MySQL volume if you want a clean DB:
+
+   ```sh
+   docker compose down -v
+   ```
+
+### Connect with DBeaver (or similar)
+
+Use the MySQL driver with these settings (from `.env`):
+
+- Host: `localhost`
+- Port: `${DB_PORT}` (e.g., 3308)
+- Database: `${MYSQL_DB}` (default `hennepin`)
+- User: `${MYSQL_USER}` (default `hennepin_user`)
+- Password: `${MYSQL_PASSWORD}` (default `password`)
+
+## Create a user (temporary, pre-frontend)
+
+Until the frontend is built, you can create users via the API (recommended for normal users) or via Django management commands (useful for a superuser/admin).
+
+### Option A — Create a user via API and get tokens
+
+Replace `8000` with your `WEB_PORT` if you changed it.
+
+1) Register a new user (returns the created user and JWT tokens):
+
+```sh
+curl -X POST http://localhost:8000/api/auth/register/ \
+   -H "Content-Type: application/json" \
+   -d '{
+      "username": "alice",
+      "email": "alice@example.com",
+      "password": "Str0ng!Pass123",
+      "password2": "Str0ng!Pass123"
+   }'
+```
+
+2) Or, if you already have a user, obtain a JWT access token:
+
+```sh
+curl -X POST http://localhost:8000/api/token/ \
+   -H "Content-Type: application/json" \
+   -d '{"username":"alice","password":"Str0ng!Pass123"}'
+```
+
+3) Use the access token to call protected endpoints (example: create a community):
+
+```sh
+curl -X POST http://localhost:8000/api/communities/ \
+   -H "Authorization: Bearer <ACCESS_TOKEN>" \
+   -H "Content-Type: application/json" \
+   -d '{"name":"TestCommunity","description":"A test community"}'
+```
+
+### Option B — Create a Django superuser (admin)
+
+Interactive (you'll be prompted for username/email/password):
+
+```sh
+docker compose exec web python manage.py createsuperuser
+```
+
+You can then log in (e.g., Django admin if enabled) and use these credentials for testing.
+
+## Running tests locally
+
+Tests default to the configured DB. To run against SQLite without MySQL, set:
+
+```sh
+USE_SQLITE=1 pytest -q
+```

--- a/app/settings.py
+++ b/app/settings.py
@@ -104,6 +104,10 @@ if env.bool('CI_SQLITE', default=False) or env.bool('USE_SQLITE', default=False)
         }
     }
 
+    # Allow overriding DEBUG and ALLOWED_HOSTS via environment for containerized runs
+    DEBUG = env.bool('DJANGO_DEBUG', default=DEBUG)
+    ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['*'])
+
 # Development-friendly DRF settings (allows unauthenticated POST for quick testing)
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DB:-hennepin}
+      MYSQL_USER: ${MYSQL_USER:-hennepin_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpassword}
+    ports:
+      - "${DB_PORT:-3307}:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${WEB_PORT:-8000}:8000"
+    volumes:
+      - .:/app:delegated
+    command: ["sh", "/app/docker/entrypoint.sh"]
+
+volumes:
+  db_data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Wait for MySQL if configured
+if [ -n "$MYSQL_HOST" ]; then
+  HOST="$MYSQL_HOST"
+  PORT="${MYSQL_PORT:-3306}"
+  echo "Waiting for database at ${HOST}:${PORT}..."
+  until nc -z "$HOST" "$PORT"; do
+    sleep 1
+  done
+  echo "Database is up."
+fi
+
+python manage.py migrate --noinput
+
+exec python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
## Summary

This PR containerizes the Django + DRF app and wires a MySQL service for easy spin-up on any machine. It also parameterizes host ports via `.env` and documents first-run steps for developers.

## Changes
- Add `Dockerfile` (python:3.10-slim) with system deps for `mysqlclient` and Pipenv-based installs
- Add `docker-compose.yml` with `web` (Django) and `db` (MySQL 8) services
  - MySQL has a healthcheck and persistent volume
  - Host ports are driven by `WEB_PORT` and `DB_PORT` in `.env`
  - Inside containers, the app connects to `MYSQL_HOST=db` on port 3306
- Add `docker/entrypoint.sh` to:
  - Wait for the DB to be reachable
  - Run `python manage.py migrate --noinput`
  - Start `runserver` on `0.0.0.0:8000`
- Add `.dockerignore`
- Update `app/settings.py` to allow env-driven `DJANGO_DEBUG` and `DJANGO_ALLOWED_HOSTS`
- Add README with Docker usage, DBeaver connection guidance, and user creation instructions
- `.env` is now the single env file for both Docker Compose and the app; `.env.example` provided

## How to run
1) Set ports in `.env` before building (avoid conflicts):
```
WEB_PORT=8000
DB_PORT=3307
```

2) Start:
```
docker compose up --build
```

- App: http://localhost:${WEB_PORT}
- MySQL for GUI tools (e.g., DBeaver): localhost:${DB_PORT}

## Developer setup notes
- The app reads env via `django-environ`; Compose passes `.env` in and overrides `MYSQL_HOST=db` in the container.
- DB data persists in the `db_data` volume.
- To create a user quickly (temporary, before frontend):
  - Register via API:
    ```sh
    curl -X POST http://localhost:${WEB_PORT}/api/auth/register/ \
      -H "Content-Type: application/json" \
      -d '{"username":"alice","email":"alice@example.com","password":"Str0ng!Pass123","password2":"Str0ng!Pass123"}'
    ```
  - Or create a superuser:
    ```sh
    docker compose exec web python manage.py createsuperuser
    ```
