### PR TITLE
feat: Add comments, subscriptions, and comprehensive tests

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -3,8 +3,7 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     UserList,
     UserDetail,
-    CommunityList,
-    CommunityDetail,
+    CommunityViewSet,
     PostViewSet,
     CommentList,
     CommentDetail,
@@ -15,13 +14,12 @@ app_name = 'api'
 
 # Router for ViewSets
 router = DefaultRouter()
+router.register(r'communities', CommunityViewSet, basename='community')
 router.register(r'posts', PostViewSet, basename='post')
 
 urlpatterns = [
     path('users/', UserList.as_view(), name='user-list'),
     path('users/<int:pk>/', UserDetail.as_view(), name='user-detail'),
-    path('communities/', CommunityList.as_view(), name='community-list'),
-    path('communities/<int:pk>/', CommunityDetail.as_view(), name='community-detail'),
     path('comments/', CommentList.as_view(), name='comment-list'),
     path('comments/<int:pk>/', CommentDetail.as_view(), name='comment-detail'),
     path("auth/register/", RegisterView.as_view(), name="auth_register"),


### PR DESCRIPTION
## Summary
This PR adds backend support for comments and subscriptions, along with comprehensive test coverage.

## Features Added
- **Subscription Endpoints**: `subscribe` and `unsubscribe` actions on CommunityViewSet
- **Comments Action**: Added `comments` action to PostViewSet to fetch all post comments
- **Comment CRUD**: CommentList and CommentDetail views with full create/read/update/delete operations
- **Atomic Updates**: comment_count updates using F() expressions to prevent race conditions

## API Changes
- `POST /communities/{id}/subscribe/` - Subscribe to a community
- `DELETE /communities/{id}/unsubscribe/` - Unsubscribe from a community
- `GET /posts/{id}/comments/` - Get all comments for a post
- `/comments/` - List and create comments
- `/comments/{id}/` - Retrieve, update, delete comment

## Serializer Enhancements
- `CommunitySerializer.is_subscribed` - Returns whether current user is subscribed
- `CommentSerializer.user` - Now uses nested UserSerializer for full user details

## Tests Added
- 5 subscription tests covering all scenarios (create, duplicate, unsubscribe, not found)
- 1 comments test for fetching post comments
- All 48 tests passing

## Database Updates
- Automatic comment_count updates on comment create/delete
- Atomic subscriber_count updates on subscribe/unsubscribe